### PR TITLE
Update references to fancybox assets

### DIFF
--- a/lib/views/general/_stylesheet_includes.html.erb
+++ b/lib/views/general/_stylesheet_includes.html.erb
@@ -14,6 +14,6 @@
         <style type="text/css">@import url("/stylesheets/ie7.css");</style>
         <![endif]-->
         <% if AlaveteliConfiguration::force_registration_on_new_request %>
-        <%= stylesheet_link_tag 'jquery.fancybox-1.3.4', :rel => "stylesheet"  %>
+            <%= stylesheet_link_tag 'fancybox.css', :rel => "stylesheet"  %>
         <% end %>
 


### PR DESCRIPTION
Alaveteli is now using fancybox-rails to handle fancybox assets.

See mysociety/alaveteli@e6d9a0ecdf291ea2f68b9e65781537bfda59ee1c
Original: mysociety/alaveteli#1422
